### PR TITLE
Ensure video uploaded has correct mimetype

### DIFF
--- a/src/api/services/multiPartUpload.ts
+++ b/src/api/services/multiPartUpload.ts
@@ -248,12 +248,12 @@ export class MultiPartUploader {
     return new Promise((resolve, reject) => {
       const controller = new AbortController();
       this.activeConnections[part.PartNumber - 1] = controller;
-      const formData = new FormData();
-      formData.append("file", file);
+      // const formData = new FormData();
+      // formData.append("file", file);
       axios
-        .put(part.signedUrl, formData, {
+        .put(part.signedUrl, file, {
           headers: {
-            "Content-Type": "multipart/form-data",
+            "Content-Type": file.type,
           },
           signal: controller.signal,
           onUploadProgress: (progressEvent) => {

--- a/src/api/services/upload.ts
+++ b/src/api/services/upload.ts
@@ -45,10 +45,11 @@ export class Uploader {
       const formData = new FormData();
       formData.append("file", this.file);
       axios
-        .put(url, formData, {
+        .put(url, this.file, {
           headers: {
-            "Content-Type": "multipart/form-data",
+            "Content-Type": this.file.type,
           },
+
           signal: controller.signal,
           onUploadProgress: (progressEvent) => {
             if (progressEvent.progress) {

--- a/src/atoms/Inputs/UploadVideoInput/VideoUpload.tsx
+++ b/src/atoms/Inputs/UploadVideoInput/VideoUpload.tsx
@@ -50,6 +50,7 @@ const VideoUpload = ({
 
   useEffect(() => {
     if (file) {
+      console.log(file);
       setPreview(URL.createObjectURL(file));
     }
 


### PR DESCRIPTION
Previous upload was not working because the mimetype was not being set correctly. 
The previos upload had the mimetype set to multipart/form-data.
This commit sets the mimetype to the correct mimetype for the video